### PR TITLE
Add key beeps to switch2477S

### DIFF
--- a/python/dimmer2477D.py
+++ b/python/dimmer2477D.py
@@ -9,7 +9,8 @@ from linkdb import *
 from querier import Querier
 from querier import MsgHandler
 from dimmer import Dimmer
-from mixins.key_beep_mixin import KeyBeepMixin
+
+from python.mixins.keybeepmixin import KeyBeepMixin
 
 from us.pfrommer.insteon.msg import Msg
 from us.pfrommer.insteon.msg import MsgListener

--- a/python/dimmer2477D.py
+++ b/python/dimmer2477D.py
@@ -9,6 +9,7 @@ from linkdb import *
 from querier import Querier
 from querier import MsgHandler
 from dimmer import Dimmer
+from mixins.key_beep_mixin import KeyBeepMixin
 
 from us.pfrommer.insteon.msg import Msg
 from us.pfrommer.insteon.msg import MsgListener
@@ -60,7 +61,7 @@ class Flags2MsgHandler(MsgHandler):
                 return 1
 
 
-class Dimmer2477D(Dimmer):
+class Dimmer2477D(Dimmer, KeyBeepMixin):
 	"""==============  Insteon SwitchLinc Dimmer 2477D ==============="""
 	def __init__(self, name, addr):
 		Dimmer.__init__(self, name, addr)
@@ -164,18 +165,6 @@ class Dimmer2477D(Dimmer):
                 This sets the LED Backlight on"""
                 self.querier.setMsgHandler(DefaultMsgHandler("Set LED Backlight ON"))
                 return self.querier.queryext(0x20, 0x09, [0x00, 0x00, 0x00]);
-
-        def setKeyBeepOn(self):
-                """setKeyBeepOn()
-                This sets the dimmer to beep when key is pressed"""
-                self.querier.setMsgHandler(DefaultMsgHandler("Set Key Beep ON"))
-                return self.querier.queryext(0x20, 0x0A, [0x00, 0x00, 0x00]);
-
-        def setKeyBeepOff(self):
-                """setKeyBeepOff()
-                This sets the dimmer to not beep when key is pressed"""
-                self.querier.setMsgHandler(DefaultMsgHandler("Set Key Beep OFF"))
-                return self.querier.queryext(0x20, 0x0B, [0x00, 0x00, 0x00]);
 
         def setRFOff(self):
                 """setRFOff()

--- a/python/handlers/defaultmessagehandler.py
+++ b/python/handlers/defaultmessagehandler.py
@@ -1,0 +1,20 @@
+"""
+DefaultMsgHandler
+
+This handler provides default message handling by sending message to standard out.
+"""
+
+import iofun
+
+from python.querier import MsgHandler
+
+def out(msg = ""):
+    iofun.out(msg)
+
+class DefaultMsgHandler(MsgHandler):
+    label = None
+    def __init__(self, l):
+            self.label = l
+    def processMsg(self, msg):
+            out(self.label + " got msg: " + msg.toString())
+            return 1

--- a/python/mixins/key_beep_mixin.py
+++ b/python/mixins/key_beep_mixin.py
@@ -1,0 +1,18 @@
+"""
+KeyBeepMixin
+
+This mixin provides functionality to control the key beep feature of some devices.
+"""
+
+class KeyBeepMixin:
+    def setKeyBeepOn(self):
+        """setKeyBeepOn()
+        This sets the dimmer to beep when key is pressed"""
+        self.querier.setMsgHandler(DefaultMsgHandler("Set Key Beep ON"))
+        return self.querier.queryext(0x20, 0x0A, [0x00, 0x00, 0x00]);
+
+    def setKeyBeepOff(self):
+        """setKeyBeepOff()
+        This sets the dimmer to not beep when key is pressed"""
+        self.querier.setMsgHandler(DefaultMsgHandler("Set Key Beep OFF"))
+        return self.querier.queryext(0x20, 0x0B, [0x00, 0x00, 0x00]);

--- a/python/mixins/keybeepmixin.py
+++ b/python/mixins/keybeepmixin.py
@@ -4,6 +4,8 @@ KeyBeepMixin
 This mixin provides functionality to control the key beep feature of some devices.
 """
 
+from python.handlers.defaultmessagehandler import DefaultMsgHandler
+
 class KeyBeepMixin:
     def setKeyBeepOn(self):
         """setKeyBeepOn()

--- a/python/switch2477S.py
+++ b/python/switch2477S.py
@@ -9,22 +9,13 @@ from querier import Querier
 from querier import MsgHandler
 from switch import Switch
 from linkdb import *
-from mixins.key_beep_mixin import KeyBeepMixin
+
+from python.handlers.defaultmessagehandler import DefaultMsgHandler
+from python.mixins.keybeepmixin import KeyBeepMixin
 
 from us.pfrommer.insteon.msg import Msg
 from us.pfrommer.insteon.msg import MsgListener
 from us.pfrommer.insteon.msg import InsteonAddress
-
-def out(msg = ""):
-	iofun.out(msg)
-
-class DefaultMsgHandler(MsgHandler):
-	label = None
-	def __init__(self, l):
-		self.label = l
-	def processMsg(self, msg):
-		out(self.label + " got msg: " + msg.toString())
-		return 1
 
 class Switch2477S(Switch, KeyBeepMixin):
 	"""==============  Insteon SwitchLinc 2477S ==============="""

--- a/python/switch2477S.py
+++ b/python/switch2477S.py
@@ -9,6 +9,7 @@ from querier import Querier
 from querier import MsgHandler
 from switch import Switch
 from linkdb import *
+from mixins.key_beep_mixin import KeyBeepMixin
 
 from us.pfrommer.insteon.msg import Msg
 from us.pfrommer.insteon.msg import MsgListener
@@ -25,7 +26,7 @@ class DefaultMsgHandler(MsgHandler):
 		out(self.label + " got msg: " + msg.toString())
 		return 1
 
-class Switch2477S(Switch):
+class Switch2477S(Switch, KeyBeepMixin):
 	"""==============  Insteon SwitchLinc 2477S ==============="""
 	def __init__(self, name, addr):
 		Switch.__init__(self, name, addr)


### PR DESCRIPTION
Code changes:
* Add a mixin for key beeps so that it can be used by both dimmer2477D and switch2477S.
* DRY up the DefaultMsgHandler since we need it for both KeyBeepMixin and switch2477S.

Notes:
* I had trouble figuring out your file naming conventions as I saw underscores, camel case, and all lowercase. I went with all lowercase as it seemed to be the most prevalent.
* I also had trouble figuring out your indention convection as I saw mixed tabs and spaces. I used spaces as that seemed more common.
* There are more things that could be moved into the handlers folder, but that is beyond the scope of adding the key beeps and I did not want to overstep. Also, I only have switch2477S. So, my ability to test changes to other devices is limited.
* My Python is quite rusty as it has been years since I have written Python. I welcome constructive criticism.

Resolves #36 